### PR TITLE
Reject enqueued message when key is duplicate of invisible message

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,8 +8,6 @@
  *  Nosto Solutions Ltd.
  */
 
-import net.ltgt.gradle.errorprone.*
-
 buildscript {
     buildscript {
         repositories {
@@ -19,8 +17,6 @@ buildscript {
             jcenter()
         }
         dependencies {
-            classpath "net.ltgt.gradle:gradle-errorprone-plugin:0.8"
-            classpath "net.ltgt.gradle:gradle-nullaway-plugin:0.2"
             classpath "com.diffplug.spotless:spotless-plugin-gradle:3.23.0"
             classpath "gradle.plugin.com.github.spotbugs.snom:spotbugs-gradle-plugin:4.0.5"
             classpath "gradle.plugin.com.dorongold.plugins:task-tree:1.5"
@@ -34,13 +30,11 @@ apply plugin: "com.github.spotbugs"
 apply plugin: 'maven'
 apply plugin: 'maven-publish'
 apply plugin: 'com.diffplug.gradle.spotless'
-apply plugin: 'net.ltgt.errorprone'
-apply plugin: 'net.ltgt.nullaway'
 apply plugin: "com.dorongold.task-tree"
 apply plugin: "jacoco"
 
 group 'com.nosto'
-version '2.0.0'
+version '2.1.0'
 
 java {
     withJavadocJar()
@@ -48,14 +42,6 @@ java {
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8
 }
-
-tasks.withType(JavaCompile).configureEach {
-    options.errorprone.nullaway {
-        //noinspection GrUnresolvedAccess
-        severity = CheckSeverity.OFF
-    }
-}
-
 
 repositories {
     google()
@@ -80,17 +66,7 @@ dependencies {
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.9.9'
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-annotations', version: '2.9.9'
     compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.9'
-    errorprone group: 'com.uber.nullaway', name: 'nullaway', version: '0.7.9'
-    errorprone group: 'com.google.errorprone', name: 'error_prone_core', version: '2.3.4'
     spotbugsPlugins group: 'com.h3xstream.findsecbugs', name: 'findsecbugs-plugin', version: '1.10.1'
-}
-
-// Configuration for the nullaway extension. The rest of the parameters must be
-// specified on the java-compile tasks. The only option that be specified here
-// is the name of the root package to be analysed.
-nullaway {
-    //noinspection GrUnresolvedAccess
-    annotatedPackages.add("com.nosto")
 }
 
 // Configuration for the Spotbugs plugin. It seems that it isn't possible to define

--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,8 @@
  *  Nosto Solutions Ltd.
  */
 
+import net.ltgt.gradle.errorprone.*
+
 buildscript {
     buildscript {
         repositories {
@@ -17,6 +19,8 @@ buildscript {
             jcenter()
         }
         dependencies {
+            classpath "net.ltgt.gradle:gradle-errorprone-plugin:0.8"
+            classpath "net.ltgt.gradle:gradle-nullaway-plugin:0.2"
             classpath "com.diffplug.spotless:spotless-plugin-gradle:3.23.0"
             classpath "gradle.plugin.com.github.spotbugs.snom:spotbugs-gradle-plugin:4.0.5"
             classpath "gradle.plugin.com.dorongold.plugins:task-tree:1.5"
@@ -30,6 +34,8 @@ apply plugin: "com.github.spotbugs"
 apply plugin: 'maven'
 apply plugin: 'maven-publish'
 apply plugin: 'com.diffplug.gradle.spotless'
+apply plugin: 'net.ltgt.errorprone'
+apply plugin: 'net.ltgt.nullaway'
 apply plugin: "com.dorongold.task-tree"
 apply plugin: "jacoco"
 
@@ -42,6 +48,14 @@ java {
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8
 }
+
+tasks.withType(JavaCompile).configureEach {
+    options.errorprone.nullaway {
+        //noinspection GrUnresolvedAccess
+        severity = CheckSeverity.OFF
+    }
+}
+
 
 repositories {
     google()
@@ -66,7 +80,17 @@ dependencies {
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.9.9'
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-annotations', version: '2.9.9'
     compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.9'
+    errorprone group: 'com.uber.nullaway', name: 'nullaway', version: '0.7.9'
+    errorprone group: 'com.google.errorprone', name: 'error_prone_core', version: '2.3.4'
     spotbugsPlugins group: 'com.h3xstream.findsecbugs', name: 'findsecbugs-plugin', version: '1.10.1'
+}
+
+// Configuration for the nullaway extension. The rest of the parameters must be
+// specified on the java-compile tasks. The only option that be specified here
+// is the name of the root package to be analysed.
+nullaway {
+    //noinspection GrUnresolvedAccess
+    annotatedPackages.add("com.nosto")
 }
 
 // Configuration for the Spotbugs plugin. It seems that it isn't possible to define

--- a/src/main/java/com/nosto/redis/queue/AbstractScript.java
+++ b/src/main/java/com/nosto/redis/queue/AbstractScript.java
@@ -175,15 +175,14 @@ abstract class AbstractScript {
         PEEK("peek"),
         PURGE("purge");
 
-        private final byte[] name;
+        private final String name;
 
         Function(String name) {
-            this.name = bytes(name);
+            this.name = name;
         }
 
         public byte[] getName() {
-            return name;
+            return bytes(name);
         }
     }
-
 }

--- a/src/main/java/com/nosto/redis/queue/AbstractScript.java
+++ b/src/main/java/com/nosto/redis/queue/AbstractScript.java
@@ -29,11 +29,6 @@ import org.apache.commons.io.IOUtils;
  */
 abstract class AbstractScript {
     /**
-     * Lua return true gets mapped to 1L.
-     */
-    private static final Long TRUE_RESPONSE = 1L;
-
-    /**
      * Adds a message to a queue.
      *
      * @param now Time now
@@ -153,7 +148,8 @@ abstract class AbstractScript {
         ArrayList<TenantMessage> result = new ArrayList<>(response.size() >> 1);
         Iterator<byte[]> it = response.iterator();
         while (it.hasNext()) {
-            result.add(new TenantMessage(new String(it.next()), new String(it.next()), it.next()));
+            result.add(new TenantMessage(new String(it.next(), StandardCharsets.UTF_8),
+                    new String(it.next(), StandardCharsets.UTF_8), it.next()));
         }
         return result;
     }
@@ -163,7 +159,7 @@ abstract class AbstractScript {
         Iterator<Object> it = response.iterator();
         while (it.hasNext()) {
             TenantStatistics tenantStatistics = new TenantStatistics(
-                    new String((byte[]) it.next()),
+                    new String((byte[]) it.next(), StandardCharsets.UTF_8),
                     (Long) it.next(),
                     (Long) it.next());
             tenantStatisticsMap.put(tenantStatistics.getTenant(), tenantStatistics);

--- a/src/main/java/com/nosto/redis/queue/AbstractScript.java
+++ b/src/main/java/com/nosto/redis/queue/AbstractScript.java
@@ -51,7 +51,7 @@ abstract class AbstractScript {
             case 0:
                 return EnqueueResult.DUPLICATE_INVISIBLE;
             case 1:
-            return EnqueueResult.SUCCESS;
+                return EnqueueResult.SUCCESS;
             case 2:
                 return EnqueueResult.DUPLICATE_OVERWRITTEN;
             default:

--- a/src/main/java/com/nosto/redis/queue/ClusterScript.java
+++ b/src/main/java/com/nosto/redis/queue/ClusterScript.java
@@ -114,6 +114,7 @@ class ClusterScript extends AbstractScript {
         }
     }
 
+    @Override
     byte[] slot(String tenant) {
         return bytes(Math.floorMod(tenant.hashCode(), numSlots));
     }

--- a/src/main/java/com/nosto/redis/queue/EnqueueResult.java
+++ b/src/main/java/com/nosto/redis/queue/EnqueueResult.java
@@ -21,5 +21,10 @@ public enum EnqueueResult {
      * The message was successfully enqueued.
      * A previously enqueued message with the same deduplication key was replaced with the newly enqueued message.
      */
-    DUPLICATE_OVERWRITTEN
+    DUPLICATE_OVERWRITTEN,
+    /**
+     * The message was not enqueued.
+     * A previously enqueued message with the same deduplication key is currently invisible and cannot be overwritten.
+     */
+    DUPLICATE_INVISIBLE
 }

--- a/src/test/java/com/nosto/redis/queue/AbstractScriptTest.java
+++ b/src/test/java/com/nosto/redis/queue/AbstractScriptTest.java
@@ -28,7 +28,7 @@ import com.palantir.docker.compose.connection.DockerPort;
 @RunWith(Parameterized.class)
 public abstract class AbstractScriptTest {
     // Names of docker services to connect to and a flag to denote if the container is a single node redis instance.
-    private static final Map<String, Boolean> CONTAINERS = ImmutableMap.<String, Boolean>builder()
+    private static final ImmutableMap<String, Boolean> CONTAINERS = ImmutableMap.<String, Boolean>builder()
             .put("redis3single", true)
             .put("redis3cluster", false)
             .put("redis4single", true)

--- a/src/test/java/com/nosto/redis/queue/AbstractScriptTest.java
+++ b/src/test/java/com/nosto/redis/queue/AbstractScriptTest.java
@@ -9,8 +9,6 @@
  */
 package com.nosto.redis.queue;
 
-import java.util.Map;
-
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.runner.RunWith;

--- a/src/test/java/com/nosto/redis/queue/LowLevelScriptTest.java
+++ b/src/test/java/com/nosto/redis/queue/LowLevelScriptTest.java
@@ -259,7 +259,7 @@ public class LowLevelScriptTest extends AbstractScriptTest {
         assertTrue(message.isPresent());
         assertEquals("t1", message.get().getTenant());
         assertEquals("foo1", message.get().getKey());
-        assertEquals("bar1", new String(message.get().getPayload()));
+        assertEquals("bar1", new String(message.get().getPayload(), StandardCharsets.UTF_8));
 
         message = script.peek(Instant.EPOCH, "q1", "t2");
         assertFalse(message.isPresent());

--- a/src/test/java/com/nosto/redis/queue/LowLevelScriptTest.java
+++ b/src/test/java/com/nosto/redis/queue/LowLevelScriptTest.java
@@ -173,9 +173,9 @@ public class LowLevelScriptTest extends AbstractScriptTest {
 
         dequeueAndAssert(Instant.EPOCH.plusSeconds(2), "q1", Duration.ofSeconds(2), "bar1");
 
-        assertEquals(EnqueueResult.DUPLICATE_INVISIBLE, script.enqueue(Instant.EPOCH, Duration.ofSeconds(5), "q1", msg2));
+        assertEquals(EnqueueResult.DUPLICATE_INVISIBLE, script.enqueue(Instant.EPOCH, Duration.ofSeconds(1), "q1", msg2));
 
-        dequeueAndAssert(Instant.EPOCH.plusSeconds(5), "q1", Duration.ZERO, "bar1");
+        dequeueAndAssert(Instant.EPOCH.plusSeconds(10), "q1", Duration.ZERO, "bar1");
     }
 
     @Test


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes -->
Currently, an enqueued message overwrites an existing visible message if the messages' keys are the same. If a message is enqueued and an existing _invisible_ message has the same key, the message is enqueued i.e. the message is not de-duplicated.

This PR rejects a message if its key matches an existing invisible message's.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Documentation:
<!--- Upon PR's approval, link the wiki page for your corresponding changes here. -->

## Checklist:
- [ ] I have updated the documentation accordingly.
- [ ] I have assigned the correct milestone or created one if non-existent.
- [ ] I have correctly labeled this pull request.
- [ ] I have linked the corresponding issue in this description.
- [ ] I have requested a review from at least 2 reviewers
- [ ] I have checked the base branch of this pull request
- [ ] I have checked my code for any possible security vulnerabilities
