### PR TITLE
Use invisible period for dequeued invisible message

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,8 +45,8 @@ version '2.1.0'
 java {
     withJavadocJar()
     withSourcesJar()
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
 }
 
 tasks.withType(JavaCompile).configureEach {

--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ apply plugin: "com.dorongold.task-tree"
 apply plugin: "jacoco"
 
 group 'com.nosto'
-version '2.1.0'
+version '2.1.1'
 
 java {
     withJavadocJar()

--- a/build.gradle
+++ b/build.gradle
@@ -45,8 +45,8 @@ version '2.1.1'
 java {
     withJavadocJar()
     withSourcesJar()
-    sourceCompatibility = JavaVersion.VERSION_11
-    targetCompatibility = JavaVersion.VERSION_11
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
 }
 
 tasks.withType(JavaCompile).configureEach {

--- a/src/main/resources/queue.lua
+++ b/src/main/resources/queue.lua
@@ -52,6 +52,10 @@ function public.dequeue(slot, queue, time, message_nexttime, maxkeys)
             local _, key = next(invisible)
             local payload = redis.call("hget", private.payload_key(slot, queue, tenant), key)
             redis.call("zadd", schedule_key, tenant_nexttime, tenant)
+
+            redis.call("zrem", invisible_key, key)
+            redis.call("zadd", invisible_key, message_nexttime, key)
+
             result[#result + 1] = tenant
             result[#result + 1] = key
             result[#result + 1] = payload

--- a/src/test/java/com/nosto/redis/queue/LowLevelScriptTest.java
+++ b/src/test/java/com/nosto/redis/queue/LowLevelScriptTest.java
@@ -51,9 +51,27 @@ public class LowLevelScriptTest extends AbstractScriptTest {
         script.enqueue(Instant.EPOCH, Duration.ofSeconds(1),
                 "q1",
                 new TenantMessage("t1", "foo", "bar".getBytes(StandardCharsets.UTF_8)));
-        dequeueAndAssert(Instant.EPOCH.plusSeconds(1), "q1", Duration.ofSeconds(2), "bar");
-        dequeueAndAssert(Instant.EPOCH.plusSeconds(2), "q1", Duration.ofSeconds(2));
-        dequeueAndAssert(Instant.EPOCH.plusSeconds(3), "q1", Duration.ofSeconds(2), "bar");
+        dequeueAndAssert(Instant.EPOCH.plusSeconds(1), "q1", Duration.ofSeconds(5), "bar");
+        dequeueAndAssert(Instant.EPOCH.plusSeconds(2), "q1", Duration.ofSeconds(5));
+        dequeueAndAssert(Instant.EPOCH.plusSeconds(3), "q1", Duration.ofSeconds(5));
+        dequeueAndAssert(Instant.EPOCH.plusSeconds(4), "q1", Duration.ofSeconds(5));
+        dequeueAndAssert(Instant.EPOCH.plusSeconds(5), "q1", Duration.ofSeconds(5));
+        dequeueAndAssert(Instant.EPOCH.plusSeconds(6), "q1", Duration.ofSeconds(10), "bar");
+        dequeueAndAssert(Instant.EPOCH.plusSeconds(7), "q1", Duration.ofSeconds(5));
+        dequeueAndAssert(Instant.EPOCH.plusSeconds(8), "q1", Duration.ofSeconds(5));
+        dequeueAndAssert(Instant.EPOCH.plusSeconds(9), "q1", Duration.ofSeconds(5));
+        dequeueAndAssert(Instant.EPOCH.plusSeconds(10), "q1", Duration.ofSeconds(5));
+        dequeueAndAssert(Instant.EPOCH.plusSeconds(11), "q1", Duration.ofSeconds(5));
+        dequeueAndAssert(Instant.EPOCH.plusSeconds(12), "q1", Duration.ofSeconds(5));
+        dequeueAndAssert(Instant.EPOCH.plusSeconds(13), "q1", Duration.ofSeconds(5));
+        dequeueAndAssert(Instant.EPOCH.plusSeconds(14), "q1", Duration.ofSeconds(5));
+        dequeueAndAssert(Instant.EPOCH.plusSeconds(15), "q1", Duration.ofSeconds(5));
+        dequeueAndAssert(Instant.EPOCH.plusSeconds(16), "q1", Duration.ofSeconds(5), "bar");
+        dequeueAndAssert(Instant.EPOCH.plusSeconds(17), "q1", Duration.ofSeconds(5));
+        dequeueAndAssert(Instant.EPOCH.plusSeconds(18), "q1", Duration.ofSeconds(5));
+        dequeueAndAssert(Instant.EPOCH.plusSeconds(19), "q1", Duration.ofSeconds(5));
+        dequeueAndAssert(Instant.EPOCH.plusSeconds(20), "q1", Duration.ofSeconds(5));
+        dequeueAndAssert(Instant.EPOCH.plusSeconds(21), "q1", Duration.ofSeconds(5), "bar");
     }
 
     @Test


### PR DESCRIPTION
The invisible period is only used when a visible message is dequeued. The invisible period should also be used when dequeuing an invisible message.